### PR TITLE
Fix semantic import versioning for v2.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/FalkorDB/falkordb-go
+module github.com/FalkorDB/falkordb-go/v2
 
 go 1.12
 


### PR DESCRIPTION
This PR fixes the semantic import versioning issue for v2.0.0 by adding the `/v2` suffix in the `go.mod` file. 
This ensures compatibility with Go's module system for major version updates.