### PR TITLE
Added error to record.GetByIndex for safe access

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,7 @@
 package falkordb
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -62,28 +63,39 @@ func checkQueryResults(t *testing.T, res *QueryResult) {
 	res.Next()
 	r := res.Record()
 
-	s, ok := r.GetByIndex(0).(*Node)
+	s, err := r.GetByIndex(0)
+	assert.NotErrorIs(t, err, ErrRecordNoValue, "First column should contain something.")
+
+	sNode, ok := s.(*Node)
 	assert.True(t, ok, "First column should contain nodes.")
-	e, ok := r.GetByIndex(1).(*Edge)
+
+	e, err := r.GetByIndex(1)
+	assert.NotErrorIs(t, err, ErrRecordNoValue, "Second column should contain something.")
+
+	eEdge, ok := e.(*Edge)
 	assert.True(t, ok, "Second column should contain edges.")
-	d, ok := r.GetByIndex(2).(*Node)
+
+	d, err := r.GetByIndex(2)
+	assert.NotErrorIs(t, err, ErrRecordNoValue, "Third column should contain something.")
+
+	dNode, ok := d.(*Node)
 	assert.True(t, ok, "Third column should contain nodes.")
 
-	assert.Equal(t, s.Labels[0], "Person", "Node should be of type 'Person'")
-	assert.Equal(t, e.Relation, "Visited", "Edge should be of relation type 'Visited'")
-	assert.Equal(t, d.Labels[0], "Country", "Node should be of type 'Country'")
+	assert.Equal(t, sNode.Labels[0], "Person", "Node should be of type 'Person'")
+	assert.Equal(t, eEdge.Relation, "Visited", "Edge should be of relation type 'Visited'")
+	assert.Equal(t, dNode.Labels[0], "Country", "Node should be of type 'Country'")
 
-	assert.Equal(t, len(s.Properties), 4, "Person node should have 4 properties")
+	assert.Equal(t, len(sNode.Properties), 4, "Person node should have 4 properties")
 
-	assert.Equal(t, s.GetProperty("name"), "John Doe", "Unexpected property value.")
-	assert.Equal(t, s.GetProperty("age"), int64(33), "Unexpected property value.")
-	assert.Equal(t, s.GetProperty("gender"), "male", "Unexpected property value.")
-	assert.Equal(t, s.GetProperty("status"), "single", "Unexpected property value.")
+	assert.Equal(t, sNode.GetProperty("name"), "John Doe", "Unexpected property value.")
+	assert.Equal(t, sNode.GetProperty("age"), int64(33), "Unexpected property value.")
+	assert.Equal(t, sNode.GetProperty("gender"), "male", "Unexpected property value.")
+	assert.Equal(t, sNode.GetProperty("status"), "single", "Unexpected property value.")
 
-	assert.Equal(t, e.GetProperty("year"), int64(2017), "Unexpected property value.")
+	assert.Equal(t, eEdge.GetProperty("year"), int64(2017), "Unexpected property value.")
 
-	assert.Equal(t, d.GetProperty("name"), "Japan", "Unexpected property value.")
-	assert.Equal(t, d.GetProperty("population"), int64(126800000), "Unexpected property value.")
+	assert.Equal(t, dNode.GetProperty("name"), "Japan", "Unexpected property value.")
+	assert.Equal(t, dNode.GetProperty("population"), int64(126800000), "Unexpected property value.")
 }
 
 func TestCreateQuery(t *testing.T) {
@@ -108,8 +120,9 @@ func TestCreateQuery(t *testing.T) {
 	assert.False(t, res.Empty(), "Expecting resultset to include a single node.")
 	res.Next()
 	r := res.Record()
-	w := r.GetByIndex(0).(*Node)
-	assert.Equal(t, w.Labels[0], "WorkPlace", "Unexpected node label.")
+	w, _ := r.GetByIndex(0)
+	wNode := w.(*Node)
+	assert.Equal(t, wNode.Labels[0], "WorkPlace", "Unexpected node label.")
 }
 
 func TestCreateROQueryFailure(t *testing.T) {
@@ -154,7 +167,9 @@ func TestArray(t *testing.T) {
 	res.Next()
 	r := res.Record()
 	assert.Equal(t, len(res.results), 1, "expecting 1 result record")
-	assert.Equal(t, []interface{}{int64(0), int64(1), int64(2)}, r.GetByIndex(0))
+	val, err := r.GetByIndex(0)
+	assert.Equal(t, []interface{}{int64(0), int64(1), int64(2)}, val)
+	assert.NoError(t, err)
 
 	q = "unwind([0,1,2]) as x return x"
 	res, err = graph.Query(q, nil, nil)
@@ -166,7 +181,18 @@ func TestArray(t *testing.T) {
 	i := 0
 	for res.Next() {
 		r = res.Record()
-		assert.Equal(t, int64(i), r.GetByIndex(0))
+		valIface, err := r.GetByIndex(0)
+		if err != nil {
+			t.Error(fmt.Errorf("error getting value: %v", err))
+			return
+		}
+		val, ok := valIface.(int64)
+		if !ok {
+			t.Error("Expected int64 result record")
+			return
+		}
+		assert.Equal(t, int64(i), val, "expecting result record")
+		assert.NoError(t, err)
 		i++
 	}
 
@@ -191,7 +217,11 @@ func TestArray(t *testing.T) {
 
 	res.Next()
 	r = res.Record()
-	arr := r.GetByIndex(0).([]interface{})
+	arrIface, err := r.GetByIndex(0)
+	assert.NoError(t, err)
+
+	arr, ok := arrIface.([]interface{})
+	assert.True(t, ok)
 
 	assert.Equal(t, 2, len(arr))
 
@@ -223,7 +253,10 @@ func TestMap(t *testing.T) {
 	}
 	res.Next()
 	r := res.Record()
-	mapval := r.GetByIndex(0).(map[string]interface{})
+	mapvalIface, err := r.GetByIndex(0)
+	assert.NoError(t, err)
+	mapval, ok := mapvalIface.(map[string]interface{})
+	assert.True(t, ok)
 
 	inner_map := map[string]interface{}{"x": []interface{}{int64(1)}}
 	expected := map[string]interface{}{"val_1": int64(5), "val_2": "str", "inner": inner_map}
@@ -236,7 +269,10 @@ func TestMap(t *testing.T) {
 	}
 	res.Next()
 	r = res.Record()
-	mapval = r.GetByIndex(0).(map[string]interface{})
+	mapvalIface, err = r.GetByIndex(0)
+	assert.NoError(t, err)
+	mapval, ok = mapvalIface.(map[string]interface{})
+	assert.True(t, ok)
 
 	expected = map[string]interface{}{"name": "Japan"}
 	assert.Equal(t, mapval, expected, "expecting a map projection")
@@ -255,7 +291,9 @@ func TestPath(t *testing.T) {
 	res.Next()
 	r := res.Record()
 
-	p, ok := r.GetByIndex(0).(Path)
+	pIface, err := r.GetByIndex(0)
+	assert.NoError(t, err)
+	p, ok := pIface.(Path)
 	assert.True(t, ok, "First column should contain path.")
 
 	assert.Equal(t, 2, p.NodesCount(), "Path should contain two nodes")
@@ -291,7 +329,10 @@ func TestPoint(t *testing.T) {
 	}
 	res.Next()
 	r := res.Record()
-	point := r.GetByIndex(0).(map[string]interface{})
+	pointIface, err := r.GetByIndex(0)
+	assert.NoError(t, err)
+	point := pointIface.(map[string]interface{})
+
 	assert.Equal(t, point["latitude"], 37.0, "Unexpected latitude value")
 	assert.Equal(t, point["longitude"], -122.0, "Unexpected longitude value")
 }
@@ -304,7 +345,10 @@ func TestVectorF32(t *testing.T) {
 	}
 	res.Next()
 	r := res.Record()
-	vec := r.GetByIndex(0).([]float32)
+	vecIface, err := r.GetByIndex(0)
+	assert.NoError(t, err)
+	vec, ok := vecIface.([]float32)
+	assert.True(t, ok)
 	assert.Equal(t, vec, []float32{1.0, 2.0, 3.0}, "Unexpected vector value")
 }
 
@@ -320,7 +364,9 @@ func TestParameterizedQuery(t *testing.T) {
 			t.Error(err)
 		}
 		res.Next()
-		assert.Equal(t, res.Record().GetByIndex(0), params[index], "Unexpected parameter value")
+		rIface, err := res.Record().GetByIndex(0)
+		assert.NoError(t, err)
+		assert.Equal(t, rIface, params[index], "Unexpected parameter value")
 	}
 }
 
@@ -424,7 +470,10 @@ func TestMultiLabelNode(t *testing.T) {
 
 	res.Next()
 	r := res.Record()
-	n := r.GetByIndex(0).(*Node)
+	nIface, err := r.GetByIndex(0)
+	assert.NoError(t, err)
+	n, ok := nIface.(*Node)
+	assert.True(t, ok)
 
 	// expecting 2 labels
 	assert.Equal(t, len(n.Labels), 2, "expecting 2 labels")

--- a/error.go
+++ b/error.go
@@ -1,0 +1,7 @@
+package falkordb
+
+import "errors"
+
+var (
+	ErrRecordNoValue = errors.New("no value")
+)

--- a/example_graph_test.go
+++ b/example_graph_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/FalkorDB/falkordb-go"
 )
 
-func ExampleSelectGraph() {
+func ExampleFalkorDB_SelectGraph() {
 	db, _ := falkordb.FalkorDBNew(&falkordb.ConnectionOption{Addr: "0.0.0.0:6379"})
 
 	graph := db.SelectGraph("social")
@@ -21,12 +21,14 @@ func ExampleSelectGraph() {
 
 	res.Next()
 	r := res.Record()
-	w := r.GetByIndex(0).(*falkordb.Node)
+	wIface, _ := r.GetByIndex(0)
+	w := wIface.(*falkordb.Node)
+
 	fmt.Println(w.Labels[0])
 	// Output: WorkPlace
 }
 
-func ExampleGraphNew_tls() {
+func ExampleFalkorDBNew() {
 	// Consider the following helper methods that provide us with the connection details (host and password)
 	// and the paths for:
 	//     tls_cert - A a X.509 certificate to use for authenticating the  server to connected clients, masters or cluster peers. The file should be PEM formatted
@@ -79,7 +81,8 @@ func ExampleGraphNew_tls() {
 
 	res.Next()
 	r := res.Record()
-	w := r.GetByIndex(0).(*falkordb.Node)
+	wIface, _ := r.GetByIndex(0)
+	w := wIface.(*falkordb.Node)
 	fmt.Println(w.Labels[0])
 }
 

--- a/graph_schema.go
+++ b/graph_schema.go
@@ -35,7 +35,12 @@ func (gs *GraphSchema) refresh_labels() error {
 	gs.labels = make([]string, len(qr.results))
 
 	for idx, r := range qr.results {
-		gs.labels[idx] = r.GetByIndex(0).(string)
+		label, err := r.GetByIndex(0)
+		if err != nil {
+			return err
+		}
+
+		gs.labels[idx] = label.(string)
 	}
 	return nil
 }
@@ -49,7 +54,11 @@ func (gs *GraphSchema) refresh_relationships() error {
 	gs.relationships = make([]string, len(qr.results))
 
 	for idx, r := range qr.results {
-		gs.relationships[idx] = r.GetByIndex(0).(string)
+		relationship, err := r.GetByIndex(0)
+		if err != nil {
+			return err
+		}
+		gs.relationships[idx] = relationship.(string)
 	}
 	return nil
 }
@@ -63,7 +72,11 @@ func (gs *GraphSchema) refresh_properties() error {
 	gs.properties = make([]string, len(qr.results))
 
 	for idx, r := range qr.results {
-		gs.properties[idx] = r.GetByIndex(0).(string)
+		property, err := r.GetByIndex(0)
+		if err != nil {
+			return err
+		}
+		gs.properties[idx] = property.(string)
 	}
 	return nil
 }

--- a/record.go
+++ b/record.go
@@ -1,24 +1,34 @@
 package falkordb
 
+import "fmt"
+
 type Record struct {
-	values	[]interface{}
-	keys	[]string
+	values []interface{}
+	keys   []string
 }
 
 func recordNew(values []interface{}, keys []string) *Record {
-	r := &Record {
+	r := &Record{
 		values: values,
-		keys: keys,
+		keys:   keys,
 	}
 
 	return r
 }
 
 func (r *Record) Keys() []string {
+	if r == nil {
+		return nil
+	}
+
 	return r.keys
 }
 
 func (r *Record) Values() []interface{} {
+	if r == nil {
+		return nil
+	}
+
 	return r.values
 }
 
@@ -32,10 +42,14 @@ func (r *Record) Get(key string) (interface{}, bool) {
 	return nil, false
 }
 
-func (r *Record) GetByIndex(index int) interface{} {
-	if(index < len(r.values)) {
-		return r.values[index]
-	} else {
-		return nil
+func (r *Record) GetByIndex(index int) (interface{}, error) {
+	if r == nil {
+		return nil, fmt.Errorf("record is nil: %w", ErrRecordNoValue)
 	}
+
+	if index >= len(r.values) {
+		return nil, ErrRecordNoValue
+	}
+
+	return r.values[index], nil
 }

--- a/record_test.go
+++ b/record_test.go
@@ -1,0 +1,65 @@
+package falkordb
+
+import (
+	"errors"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestRecord_GetByIndex_WhenNil(t *testing.T) {
+	var record *Record
+	_, err := record.GetByIndex(-1)
+	if !errors.Is(err, ErrRecordNoValue) {
+		assert.FailNow(t, err.Error())
+	}
+}
+
+func TestRecord_GetByIndex(t *testing.T) {
+	type fields struct {
+		values []interface{}
+		keys   []string
+	}
+	type args struct {
+		index int
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    interface{}
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "GetByIndex where record is",
+			fields: fields{
+				keys: []string{
+					"foo",
+					"baz",
+				},
+				values: []interface{}{
+					"bar",
+					"buzz",
+				},
+			},
+			args: args{
+				index: 1,
+			},
+			want:    "buzz",
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Record{
+				values: tt.fields.values,
+				keys:   tt.fields.keys,
+			}
+			got, err := r.GetByIndex(tt.args.index)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetByIndex(%v)", tt.args.index)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "GetByIndex(%v)", tt.args.index)
+		})
+	}
+}


### PR DESCRIPTION
Hey! First time contributor.

I was using this library to interact with a some example code within the documentation at (https://docs.falkordb.com/getting-started.html). Noting that Go is not one of the languages listed in these examples. I found that I was able to create panics while reading from values.

I intended to add memory save access to the Record access, and have added an `ErrNoValue` to `errors.go` and testing for the `record.go` file.