### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,6 +10,7 @@ jobs:
   update_release_draft:
     permissions:
       contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"


### PR DESCRIPTION
Potential fix for [https://github.com/FalkorDB/falkordb-go/security/code-scanning/2](https://github.com/FalkorDB/falkordb-go/security/code-scanning/2)

The best way to fix this issue is to explicitly declare the required permissions for the job (or the entire workflow) using the `permissions` key. For Release Drafter, the action needs `contents: write` (to manage draft releases) but does not need broader permissions. To implement, add a `permissions` block at the job level (indented to match) specifying the minimal required permissions. This should be done immediately under the job name in `.github/workflows/release-drafter.yml` (i.e., after `update_release_draft:` and before `runs-on:`).

No imports or methods are needed; this is a declarative YAML configuration change only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

 
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to support release drafting functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
 
 
 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses a code scanning alert by adding explicit permissions to the `release-drafter.yml` GitHub Actions workflow, ensuring it has the necessary access to write contents and pull requests.

#### Key Changes
- Added `contents: write` and `pull-requests: write` permissions to the `update_release_draft` job in `.github/workflows/release-drafter.yml`.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 3 (100.0%)    |
| Total Changes | 3             | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>