### PR TITLE
Fix: disable go-redis default 3s read timeout that kills long-running queries

### DIFF
--- a/falkordb.go
+++ b/falkordb.go
@@ -96,6 +96,7 @@ func FalkorDBNew(options *ConnectionOption) (*FalkorDB, error) {
 
 // FalkorDBNewCluster creates a new FalkorDB cluster instance.
 func FalkorDBNewCluster(options *ConnectionClusterOption) (*FalkorDB, error) {
+	applyDefaultTimeouts(&options.ReadTimeout, &options.WriteTimeout)
 	db := redis.NewClusterClient(options)
 	return &FalkorDB{Conn: db}, nil
 }
@@ -112,6 +113,7 @@ func FromURL(url string) (*FalkorDB, error) {
 	if err != nil {
 		return nil, err
 	}
+	applyDefaultTimeouts(&options.ReadTimeout, &options.WriteTimeout)
 	db := redis.NewClient(options)
 	if isSentinel(db) {
 		masters, err := db.Do(ctx, "SENTINEL", "MASTERS").Result()
@@ -125,6 +127,8 @@ func FromURL(url string) (*FalkorDB, error) {
 		db = redis.NewFailoverClient(&redis.FailoverOptions{
 			MasterName:    masterName,
 			SentinelAddrs: []string{options.Addr},
+			ReadTimeout:   options.ReadTimeout,
+			WriteTimeout:  options.WriteTimeout,
 		})
 	}
 	return &FalkorDB{Conn: db}, nil

--- a/falkordb.go
+++ b/falkordb.go
@@ -4,11 +4,16 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 )
 
 var ctx = context.Background()
+
+// noTimeout disables go-redis' client-side read/write deadline (go-redis
+// treats -1 as "no timeout", while 0 silently means the 3 second default).
+const noTimeout = -1
 
 type FalkorDB struct {
 	Conn redis.UniversalClient
@@ -34,8 +39,26 @@ func isSentinel(conn redis.UniversalClient) bool {
 	return svr["redis_mode"] == "sentinel"
 }
 
+// applyDefaultTimeouts disables the client-side read/write deadline when the
+// caller did not set one explicitly. Graph queries routinely exceed go-redis'
+// default 3 second ReadTimeout (bulk loads, deep traversals), which would cut
+// the connection with an i/o timeout - and go-redis then retries the command,
+// re-executing writes - while the server keeps running the query. Query
+// duration is governed by the server's TIMEOUT / TIMEOUT_DEFAULT configuration
+// instead, matching the other FalkorDB clients. Callers can still opt into a
+// deadline by setting ReadTimeout / WriteTimeout explicitly.
+func applyDefaultTimeouts(readTimeout, writeTimeout *time.Duration) {
+	if *readTimeout == 0 {
+		*readTimeout = noTimeout
+	}
+	if *writeTimeout == 0 {
+		*writeTimeout = noTimeout
+	}
+}
+
 // FalkorDB Class for interacting with a FalkorDB server.
 func FalkorDBNew(options *ConnectionOption) (*FalkorDB, error) {
+	applyDefaultTimeouts(&options.ReadTimeout, &options.WriteTimeout)
 	db := redis.NewClient(options)
 
 	if isSentinel(db) {
@@ -64,6 +87,8 @@ func FalkorDBNew(options *ConnectionOption) (*FalkorDB, error) {
 			PoolFIFO:         options.PoolFIFO,
 			PoolSize:         options.PoolSize,
 			PoolTimeout:      options.PoolTimeout,
+			ReadTimeout:      options.ReadTimeout,
+			WriteTimeout:     options.WriteTimeout,
 		})
 	}
 	return &FalkorDB{Conn: db}, nil


### PR DESCRIPTION
## Problem

go-redis v9 silently applies a **3 second ReadTimeout** when `Options.ReadTimeout` is left at 0. Any graph query taking longer than 3 seconds (bulk loads, deep traversals) fails with:

```
read tcp 127.0.0.1:53632->127.0.0.1:6499: i/o timeout
```

Worse, go-redis **automatically retries the command up to 3 times** (observed failure at ~12s = 3s x 4 attempts), re-executing write queries and duplicating data, while the server keeps running the original query.

Same class of bug already fixed in falkordb-rs (FalkorDB/falkordb-rs#297, redis-rs 500ms default) and JFalkorDB (FalkorDB/JFalkorDB#282, Jedis 2000ms default). falkordb-py, falkordb-ts and falkordb-php are unaffected.

## Fix

When the caller leaves `ReadTimeout`/`WriteTimeout` unset, default them to **-1 (no client-side deadline)** in all entry points: `FalkorDBNew`, `FalkorDBNewCluster`, `FromURL`, plus both sentinel failover paths (which previously dropped the timeouts entirely). Query duration is governed by the server's `TIMEOUT` / `TIMEOUT_DEFAULT` configuration, consistent with the other FalkorDB clients. Explicitly-set timeouts are fully respected.

## Validation

Against FalkorDB v4.20.1, `UNWIND range(1,80000000) AS x RETURN sum(x)` (~4-5s):

| | before | after |
|---|---|---|
| `FalkorDBNew` | fails at ~12s (3s timeout x 3 silent retries) | **OK in 5.3s**, correct result |
| `FromURL` | same failure | **OK in 4.2s**, correct result |
| explicit `ReadTimeout: 2s` | n/a | still times out as expected (opt-in preserved) |

- `go build`, `go vet`, `gofmt` clean
- Full test suite passes