### PR TITLE
ci: test PRs against falkordb:latest and add a daily edge canary

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     services:
       falkordb:
-        image: falkordb/falkordb:edge
+        # The officially released server. PRs and pushes gate on the version users actually run;
+        # the moving `edge` tag is exercised daily by version-canary.yml instead, where a server-side
+        # change cannot block a merge.
+        image: falkordb/falkordb:latest
         ports:
           - 6379:6379
     steps:


### PR DESCRIPTION
PRs and pushes here ran against **`falkordb/falkordb:edge`** — a moving tag rebuilt from the server's development branch. That gates every merge on unreleased server changes, and it is why this repo's CI is currently red.

This splits the two concerns:

| Trigger | Image | Blocking? |
| --- | --- | --- |
| `pull_request`, `push` (`Go` workflow) | `falkordb/falkordb:latest` | yes — required |
| daily 05:00 UTC + `workflow_dispatch` (`FalkorDB version canary`) | `falkordb/falkordb:edge` | no — cannot gate a merge |

## Verified locally against both images

`go test -count=1 ./...` with each image running as the server:

```
falkordb/falkordb:latest    ok       all tests pass
falkordb/falkordb:edge      FAIL     TestArray, TestCreateIndex
```

**Both `edge` failures are server-side changes, not client bugs**, and both are worth the server team's attention:

1. **Array results parse as `nil`.** `edge` appends a `Graph version:` field to the query response metadata, which shifts the reply structure. Confirmed at the protocol level with `redis-cli`: `RETURN [0,1,2]` returns the correct array on *both* images, but only `edge` appends the extra field — so the client's positional parse of the reply lands on the wrong element.
2. **`DROP INDEX` error gained an `ERR ` prefix** on a non-existent index, so `TestCreateIndex`'s expected string no longer matches.

The first one is the more serious of the two: any client that parses the reply positionally will silently return `nil` for array values against `edge`.

## What this means for CI here

- The `Go` workflow should go **green** on this PR — it now runs `latest`, which passes. This also unblocks #105.
- **The first canary run will be red**, reporting the two failures above. That is the workflow doing its job, not a broken PR. It stays out of the required checks, so it cannot block anything.

## Notes on the implementation

- `-count=1` in the canary disables Go's test result cache. Without it a cached `ok` would mask a regression, because the source is unchanged between canary runs and only the server moves. I hit this while testing — the first run reported `(cached)` and silently reused the previous image's result.
- The canary uses a one-entry `image` matrix, so adding `falkordb/falkordb:latest` alongside `edge` is a one-line change if you want the daily run to also catch "`latest` moved and broke us" — `latest` is a moving tag too, and today nothing notices it changing until someone opens a PR. [`JFalkorDB`'s existing canary](https://github.com/FalkorDB/JFalkorDB/blob/master/.github/workflows/version-canary.yml) does exactly that. I kept it to `edge` only to match the stated policy — say the word and I'll add it.
- Action SHAs and the Go version are copied from the existing `Go` workflow, so the canary stays consistent with it.
- Naming follows `JFalkorDB`'s `version-canary.yml` / "FalkorDB version canary" so the workflow is recognisable across the org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated testing environment to use the stable FalkorDB release image.
  * Added documentation clarifying where the edge image is tested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->