### PR TITLE
ci(go): run tests against latest, edge daily

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,8 +8,19 @@ permissions:
 on:
   push:
     branches: [ "master" ]
+    tags: [ "v*" ]
   pull_request:
     branches: [ "master" ]
+  # Daily run against the `edge` image to catch breaking changes in upcoming
+  # FalkorDB releases before they reach a stable release.
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+    inputs:
+      falkordb_image_tag:
+        description: "FalkorDB Docker image tag to test against (defaults to latest)"
+        required: false
+        default: ""
 
 jobs:
 
@@ -17,7 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     services:
       falkordb:
-        image: falkordb/falkordb:edge
+        # Released `latest` for PRs/pushes/tags, `edge` for the scheduled daily
+        # run (or an explicit tag on manual dispatch).
+        image: falkordb/falkordb:${{ github.event.inputs.falkordb_image_tag || (github.event_name == 'schedule' && 'edge' || 'latest') }}
         ports:
           - 6379:6379
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,32 +22,39 @@ on:
         required: false
         default: ""
 
-env:
-  # FalkorDB image tag under test: the released `latest` for pull requests,
-  # pushes and tags, `edge` for the scheduled daily run, or an explicit tag on
-  # manual dispatch.
-  FALKORDB_VERSION: ${{ github.event.inputs.falkordb_image_tag || (github.event_name == 'schedule' && 'edge' || 'latest') }}
 
 jobs:
 
+  # Single source of truth for the FalkorDB image tag. It cannot be a plain
+  # `env:` variable because GitHub does not allow the `env` context in
+  # `jobs.<id>.services.<id>.image`, so it is resolved once here and consumed
+  # via `needs.falkordb-version.outputs.version`.
+  falkordb-version:
+    name: Resolve FalkorDB version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - id: resolve
+        env:
+          # Released `latest` for pull requests, pushes and tags; `edge` for the
+          # scheduled daily run; an explicit tag on manual dispatch.
+          FALKORDB_VERSION: ${{ github.event.inputs.falkordb_image_tag || (github.event_name == 'schedule' && 'edge' || 'latest') }}
+        run: |
+          echo "Testing against falkordb/falkordb:$FALKORDB_VERSION"
+          echo "version=$FALKORDB_VERSION" >> "$GITHUB_OUTPUT"
+
   build:
     runs-on: ubuntu-latest
+    needs: falkordb-version
+    services:
+      falkordb:
+        # Tag resolved by the `falkordb-version` job above.
+        image: falkordb/falkordb:${{ needs.falkordb-version.outputs.version }}
+        ports:
+          - 6379:6379
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-    - name: Start FalkorDB
-      run: |
-        docker run -d --name falkordb -p 6379:6379 "falkordb/falkordb:$FALKORDB_VERSION"
-        for _ in $(seq 1 30); do
-          if docker exec falkordb redis-cli ping | grep -q PONG; then
-            echo "FalkorDB $FALKORDB_VERSION is ready"
-            exit 0
-          fi
-          sleep 2
-        done
-        echo "FalkorDB $FALKORDB_VERSION failed to become ready"
-        docker logs falkordb
-        exit 1
 
     - name: Set up Go
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,19 +22,32 @@ on:
         required: false
         default: ""
 
+env:
+  # FalkorDB image tag under test: the released `latest` for pull requests,
+  # pushes and tags, `edge` for the scheduled daily run, or an explicit tag on
+  # manual dispatch.
+  FALKORDB_VERSION: ${{ github.event.inputs.falkordb_image_tag || (github.event_name == 'schedule' && 'edge' || 'latest') }}
+
 jobs:
 
   build:
     runs-on: ubuntu-latest
-    services:
-      falkordb:
-        # Released `latest` for PRs/pushes/tags, `edge` for the scheduled daily
-        # run (or an explicit tag on manual dispatch).
-        image: falkordb/falkordb:${{ github.event.inputs.falkordb_image_tag || (github.event_name == 'schedule' && 'edge' || 'latest') }}
-        ports:
-          - 6379:6379
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+    - name: Start FalkorDB
+      run: |
+        docker run -d --name falkordb -p 6379:6379 "falkordb/falkordb:$FALKORDB_VERSION"
+        for _ in $(seq 1 30); do
+          if docker exec falkordb redis-cli ping | grep -q PONG; then
+            echo "FalkorDB $FALKORDB_VERSION is ready"
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "FalkorDB $FALKORDB_VERSION failed to become ready"
+        docker logs falkordb
+        exit 1
 
     - name: Set up Go
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ on:
       falkordb_image_tag:
         description: "FalkorDB Docker image tag to test against (defaults to latest)"
         required: false
-        default: ""
+        default: "latest"
 
 
 jobs:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -67,9 +67,9 @@ jobs:
     - name: Test
       run: go test -v ./...
 
-  # A cron job has nobody watching it: GitHub only emails the user who last
-  # touched the cron line, so a silent daily failure is the default outcome.
-  # Failures therefore open a tracking issue (or comment on the open one).
+  # A cron job has nobody watching it: GitHub only emails whoever last touched
+  # the cron line, so a failing daily run would otherwise go unnoticed. Post it
+  # to Google Chat instead.
   report-scheduled-failure:
     name: Report scheduled failure
     needs: [falkordb-version, build]
@@ -77,13 +77,31 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+    env:
+      GOOGLE_CHAT_WEBHOOK_URL: ${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}
+      REPO: ${{ github.repository }}
+      WORKFLOW: ${{ github.workflow }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
-      - name: Open or update the tracking issue
+      - name: Notify Google Chat
+        if: ${{ env.GOOGLE_CHAT_WEBHOOK_URL != '' }}
+        run: |
+          text=$(printf '%s\n' \
+            "*$REPO* — the daily \`$WORKFLOW\` run against \`falkordb/falkordb:edge\` failed." \
+            "<$RUN_URL|View the run>" \
+            "" \
+            "\`edge\` is an unreleased FalkorDB build, so released users are unaffected: this is an early warning that the next FalkorDB release breaks this client.")
+          jq -n --arg text "$text" '{text: $text}' > payload.json
+          curl -sS --fail-with-body -X POST -H 'Content-Type: application/json' \
+            -d @payload.json "$GOOGLE_CHAT_WEBHOOK_URL"
+
+      # Fallback while the webhook secret is not configured, so the signal is
+      # never lost. Opens one issue and comments on it on subsequent failures.
+      - name: Open or update a tracking issue
+        if: ${{ env.GOOGLE_CHAT_WEBHOOK_URL == '' }}
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          WORKFLOW: ${{ github.workflow }}
           TITLE: "CI is failing against falkordb/falkordb:edge"
         run: |
           body=$(printf '%s\n' \
@@ -91,7 +109,7 @@ jobs:
             "" \
             "$RUN_URL" \
             "" \
-            "\`edge\` is an unreleased FalkorDB build, so this does not affect users on \`latest\`: it is an early warning that something in the next FalkorDB release breaks this client.")
+            "Set the \`GOOGLE_CHAT_WEBHOOK_URL\` secret to receive this in Google Chat instead.")
           number=$(gh issue list --state open --search "$TITLE in:title" --json number,title \
             --jq "map(select(.title == \"$TITLE\")) | .[0].number // empty")
           if [ -n "$number" ]; then

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -66,3 +66,36 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+
+  # A cron job has nobody watching it: GitHub only emails the user who last
+  # touched the cron line, so a silent daily failure is the default outcome.
+  # Failures therefore open a tracking issue (or comment on the open one).
+  report-scheduled-failure:
+    name: Report scheduled failure
+    needs: [falkordb-version, build]
+    if: ${{ always() && github.event_name == 'schedule' && contains(needs.*.result, 'failure') }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          WORKFLOW: ${{ github.workflow }}
+          TITLE: "CI is failing against falkordb/falkordb:edge"
+        run: |
+          body=$(printf '%s\n' \
+            "The daily \`$WORKFLOW\` run against \`falkordb/falkordb:edge\` failed." \
+            "" \
+            "$RUN_URL" \
+            "" \
+            "\`edge\` is an unreleased FalkorDB build, so this does not affect users on \`latest\`: it is an early warning that something in the next FalkorDB release breaks this client.")
+          number=$(gh issue list --state open --search "$TITLE in:title" --json number,title \
+            --jq "map(select(.title == \"$TITLE\")) | .[0].number // empty")
+          if [ -n "$number" ]; then
+            gh issue comment "$number" --body "$body"
+          else
+            gh issue create --title "$TITLE" --body "$body"
+          fi


### PR DESCRIPTION
## Summary
CI validated every PR against `falkordb/falkordb:edge`, an unreleased build — so PRs could break for reasons unrelated to the change, and nothing verified the client against the FalkorDB version users actually run. This flips the default to the released `latest` image and moves `edge` to a daily scheduled run, which is where early warnings about upcoming FalkorDB releases belong.

## Changes
- Build + tests run against `falkordb/falkordb:latest` on pull requests, pushes to `master` and version tags (`v*` — newly added trigger, so releases are tested).
- New daily schedule (02:00 UTC) runs the same suite against `falkordb/falkordb:edge`.
- New `workflow_dispatch` with an optional `falkordb_image_tag` input to test an arbitrary tag on demand.
- The FalkorDB service container's image tag now comes from the shared resolver job instead of being hardcoded.

Job names are unchanged, so existing branch-protection required checks keep working.

## The standard, in all seven clients
Every official client picks the image tag with the same expression:

```
${{ github.event.inputs.falkordb_image_tag || (github.event_name == 'schedule' && 'edge' || 'latest') }}
```

`latest` for pull requests, pushes, tags and releases; `edge` for the daily scheduled run; any tag on manual dispatch.

Clients that start FalkorDB with docker compose (falkordb-ts, falkordb-php) keep it in a workflow-level `FALKORDB_VERSION`, which compose reads as `falkordb/falkordb:${FALKORDB_VERSION:-latest}`.

Clients that run FalkorDB as a **service container** keep doing exactly that — the service container is the idiomatic mechanism and gets networking, health checks and cleanup from the runner for free. The tag still has a single definition, but it cannot be an `env:` variable: GitHub does not allow the `env` context in `jobs.<id>.services.<id>.image` ([context availability](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#context-availability)). A small `falkordb-version` job resolves it once and every job consumes it:

```yaml
jobs:
  falkordb-version:
    name: Resolve FalkorDB version
    runs-on: ubuntu-latest
    outputs:
      version: ${{ steps.resolve.outputs.version }}
    steps:
      - id: resolve
        env:
          FALKORDB_VERSION: ${{ github.event.inputs.falkordb_image_tag || (github.event_name == 'schedule' && 'edge' || 'latest') }}
        run: echo "version=$FALKORDB_VERSION" >> "$GITHUB_OUTPUT"

  test:
    needs: falkordb-version
    services:
      falkordb:
        image: falkordb/falkordb:${{ needs.falkordb-version.outputs.version }}
```

## Failure notifications
The daily `edge` run posts to Google Chat when it fails. GitHub itself only emails whoever last edited the cron line, so without this the early-warning run would fail silently.

Add a Google Chat **incoming webhook** for the target space and store it as an Actions secret named `GOOGLE_CHAT_WEBHOOK_URL` — ideally once at organisation level so all seven clients share it:

```bash
gh secret set GOOGLE_CHAT_WEBHOOK_URL --org FalkorDB --visibility all
```

Until that secret exists the job falls back to opening (or commenting on) a tracking issue, so the signal is never lost. The step only runs on `schedule` failures; manual and PR runs are already visible to whoever triggered them. The message is built with `jq`, and no `${{ }}` expression is expanded into the shell.

## Testing
Verified by this PR's own runs: they must pull `falkordb/falkordb:latest` and the readiness check must report it before the suite starts. The `edge` path was verified end to end by dispatching the workflow with `falkordb_image_tag=edge` (the run pulled `falkordb/falkordb:edge`).

## Memory / Performance Impact
N/A — CI configuration only.

## Related Issues
N/A



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated workflows to run for version tags, scheduled daily executions, and manual triggers.
  * Added optional image-tag selection for manual runs.
  * Updated builds to automatically use the appropriate FalkorDB image tag based on the trigger type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
