### PR TITLE
ci(go): derive Go toolchain version from go.mod

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6
       with:
-        go-version: '1.21'
+        go-version-file: go.mod
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
## Summary
CI pinned `go-version: '1.21'` in `.github/workflows/go.yml` while `go.mod` carries the module's own Go directive. Any dependency bump that raises that directive breaks the build, e.g. #94 (go-redis v9.22.0 requires `go >= 1.24`):

```
go: go.mod requires go >= 1.24 (running go 1.21.13; GOTOOLCHAIN=local)
```

## Changes
- `setup-go` now uses `go-version-file: go.mod` instead of a hard-coded `1.21`.

## Testing
- CI on this PR builds and tests against `falkordb/falkordb:latest` (go.mod still declares 1.21 here, so behaviour is unchanged for master).
- Unblocks #94, which raises the directive to 1.24.

## Memory / Performance Impact
N/A.

## Related Issues
Unblocks #94.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go build workflow to automatically use the version specified by the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->