### PR TITLE
ci: actually run the tests on the daily edge job

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,6 +47,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: falkordb-version
+
+    # Without this the job inherits the 6 hour default, so a hung suite holds a
+    # runner all morning and then reports `cancelled` rather than failing.
+    timeout-minutes: 30
+
     services:
       falkordb:
         # Tag resolved by the `falkordb-version` job above.
@@ -65,7 +70,11 @@ jobs:
       run: go build -v ./...
 
     - name: Test
-      run: go test -v ./...
+      # -count=1 disables the test cache. The results only depend on the source,
+      # as far as `go test` can tell, so a run against `edge` happily replays a
+      # pass recorded against `latest` and reports `(cached)` without contacting
+      # the server at all. That makes the daily `edge` run report nothing.
+      run: go test -count=1 -v ./...
 
   # A cron job has nobody watching it: GitHub only emails whoever last touched
   # the cron line, so a failing daily run would otherwise go unnoticed. The
@@ -75,7 +84,10 @@ jobs:
   report-scheduled-failure:
     name: Report scheduled failure
     needs: [falkordb-version, build]
-    if: ${{ always() && github.event_name == 'schedule' && contains(needs.*.result, 'failure') }}
+    # `cancelled` as well as `failure`: a job stopped by its own timeout, or one
+    # that ran into GitHub's six hour ceiling, reports `cancelled`, and a nightly
+    # that hangs is exactly the case this alert exists for.
+    if: ${{ always() && github.event_name == 'schedule' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
     permissions:
       issues: write
     # Pinned, and only the one secret it declares is passed: a mutable ref


### PR DESCRIPTION
The daily `edge` job has been reporting green without running any tests.

`go test` keys its cache on the source and the test binary, not on the
server the tests talk to. The PR/push runs use `latest` and record a pass;
the 02:00 run uses `edge`, restores the same cache, and replays it. From the
log of a recent nightly:

```
Testing against falkordb/falkordb:edge
ok  github.com/FalkorDB/falkordb-go/v2  (cached)
```

Every test prints PASS with the same millisecond timestamp and the job
finishes in about 20 seconds, because nothing connected to the server.

Reproduced locally with one shared build cache and two servers:

```
# 1. against latest, like a PR run
$ go test ./...
ok      github.com/FalkorDB/falkordb-go/v2      0.039s

# 2. same cache, now against edge, like the nightly
$ go test ./...
ok      github.com/FalkorDB/falkordb-go/v2      (cached)

# 3. same cache, same edge server, with -count=1
$ go test -count=1 ./...
--- FAIL: TestCreateIndex (0.00s)
--- FAIL: TestTimeout (0.00s)
FAIL
```

So `-count=1` on the test step.

Heads up: this will turn the daily `edge` run red, with `TestCreateIndex`
and `TestTimeout` failing. Those are real differences against the current
`edge` image that the cache has been hiding. The job is non-blocking and
does not gate PRs, which still run against `latest`.

Also in here, same as the sibling PRs in the other clients:

- `report-scheduled-failure` now fires on `cancelled` as well as `failure`.
  A job stopped by a timeout, or by GitHub's six hour ceiling, reports
  `cancelled`, so the alert was skipped whenever a nightly hung.
- `timeout-minutes: 30` on the build job, so a hang fails the same morning
  instead of holding a runner until the six hour ceiling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated build reliability with a 30-minute job timeout.
  * Ensured Go tests always run fresh rather than using cached results.
  * Expanded scheduled failure reporting to include cancelled jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->