### PR TITLE
fix(params): stop panicking on ordinary values and block Cypher injection

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -12,3 +12,8 @@ www
 faq
 UDF
 UDFs
+Cypher
+booleans
+NUL
+UTF
+FalkorDB's

--- a/README.md
+++ b/README.md
@@ -67,7 +67,10 @@ func main() {
 		r := result.Record()
 
 		// Entries in the Record can be accessed by index or key.
-		pName := r.GetByIndex(0)
+		pName, err := r.GetByIndex(0)
+		if err != nil {
+			log.Fatal(err)
+		}
 		fmt.Printf("\nName: %s\n", pName)
 		pAge, _ := r.Get("p.age")
 		fmt.Printf("\nAge: %d\n", pAge)
@@ -79,10 +82,14 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println("Pathes of persons visiting countries:")
+	fmt.Println("Paths of persons visiting countries:")
 	for result.Next() {
 		r := result.Record()
-		p, ok := r.GetByIndex(0).(falkordb.Path)
+		v, err := r.GetByIndex(0)
+		if err != nil {
+			log.Fatal(err)
+		}
+		p, ok := v.(falkordb.Path)
 		fmt.Printf("%s %v\n", p, ok)
 	}
 }
@@ -102,6 +109,45 @@ Query internal execution time 1.623063
 Name: John Doe
 
 Age: 33
+```
+
+## Query parameters
+
+Pass parameters as a map rather than interpolating values into the query string:
+
+```go
+params := map[string]interface{}{"name": "John Doe", "minAge": 18}
+res, err := graph.Query("MATCH (p:Person {name: $name}) WHERE p.age > $minAge RETURN p", params, nil)
+```
+
+Supported parameter types are `nil`, strings, `[]byte`, booleans, every signed and
+unsigned integer type, `float32`, `float64`, `time.Time`, `time.Duration`, slices
+and arrays of any supported type, and maps with string keys. Values that cannot be
+represented are reported as an error wrapping `falkordb.ErrUnsupportedType`.
+
+A `time.Time` is sent as an RFC 3339 string and a `time.Duration` as a whole number
+of seconds, matching FalkorDB's second-granularity `DURATION` type.
+
+Parameter names must be plain Cypher identifiers, and map keys are back-quoted, so
+neither can inject Cypher into the query. Because FalkorDB strings are UTF-8 text,
+a `[]byte` must hold valid UTF-8 and no value may contain a NUL byte; anything else
+is rejected rather than silently corrupted. Integers above `math.MaxInt64` are
+rejected too, since the server would otherwise saturate them without an error.
+
+## Temporal values
+
+FalkorDB's `date()`, `localtime()`, `localdatetime()` and `duration()` values are
+decoded into native Go types — `time.Time` for the first three and `time.Duration`
+for the last:
+
+```go
+res, _ := graph.Query("RETURN date(), duration({days: 2})", nil, nil)
+for res.Next() {
+	values := res.Record().Values()
+	day := values[0].(time.Time)
+	span := values[1].(time.Duration)
+	fmt.Println(day, span)
+}
 ```
 
 ## Running queries with timeouts

--- a/README.md
+++ b/README.md
@@ -130,9 +130,10 @@ of seconds, matching FalkorDB's second-granularity `DURATION` type.
 
 Parameter names must be plain Cypher identifiers, and map keys are back-quoted, so
 neither can inject Cypher into the query. Because FalkorDB strings are UTF-8 text,
-a `[]byte` must hold valid UTF-8 and no value may contain a NUL byte; anything else
-is rejected rather than silently corrupted. Integers above `math.MaxInt64` are
-rejected too, since the server would otherwise saturate them without an error.
+strings and `[]byte` must hold valid UTF-8 and no value may contain a NUL byte;
+anything else is rejected rather than silently corrupted. Integers above
+`math.MaxInt64` are rejected too, since the server would otherwise saturate them
+without an error.
 
 ## Temporal values
 

--- a/client_test.go
+++ b/client_test.go
@@ -455,7 +455,9 @@ func TestUtils(t *testing.T) {
 	jsonMap := make(map[string]interface{})
 	jsonMap["object"] = map[string]interface{}{"foo": 1}
 	res = ToString(jsonMap)
-	assert.Equal(t, res, "{object: {foo: 1}}")
+	// Map keys are back-quoted so that a key cannot close the literal and
+	// append arbitrary Cypher.
+	assert.Equal(t, res, "{`object`: {`foo`: 1}}")
 }
 
 func TestMultiLabelNode(t *testing.T) {

--- a/error.go
+++ b/error.go
@@ -4,4 +4,8 @@ import "errors"
 
 var (
 	ErrRecordNoValue = errors.New("no value")
+
+	// ErrUnsupportedType is returned when a value cannot be represented as a
+	// Cypher literal, for example when it is passed as a query parameter.
+	ErrUnsupportedType = errors.New("unsupported type")
 )

--- a/graph.go
+++ b/graph.go
@@ -63,7 +63,11 @@ func (options *QueryOptions) GetTimeout() int {
 
 func (g *Graph) query(command string, query string, params map[string]interface{}, options *QueryOptions) (*QueryResult, error) {
 	if params != nil {
-		query = BuildParamsHeader(params) + query
+		header, err := buildParamsHeader(params)
+		if err != nil {
+			return nil, err
+		}
+		query = header + query
 	}
 	var r interface{}
 	var err error
@@ -96,8 +100,12 @@ func (g *Graph) CallProcedure(procedure string, yield []string, args ...interfac
 	query := fmt.Sprintf("CALL %s(", procedure)
 
 	tmp := make([]string, 0, len(args))
-	for arg := range args {
-		tmp = append(tmp, ToString(arg))
+	for _, arg := range args {
+		s, err := toString(arg)
+		if err != nil {
+			return nil, err
+		}
+		tmp = append(tmp, s)
 	}
 	query += fmt.Sprintf("%s)", strings.Join(tmp, ","))
 

--- a/query_result.go
+++ b/query_result.go
@@ -88,7 +88,9 @@ func QueryResultNew(g *Graph, response interface{}) (*QueryResult, error) {
 	}
 
 	if len(r) == 1 {
-		qr.parseStatistics(r[0])
+		if err := qr.parseStatistics(r[0]); err != nil {
+			return nil, err
+		}
 	} else {
 		if len(r) < 3 {
 			return nil, fmt.Errorf("malformed response: expected 3 elements, got %d", len(r))
@@ -96,7 +98,9 @@ func QueryResultNew(g *Graph, response interface{}) (*QueryResult, error) {
 		if err := qr.parseResults(r); err != nil {
 			return nil, err
 		}
-		qr.parseStatistics(r[2])
+		if err := qr.parseStatistics(r[2]); err != nil {
+			return nil, err
+		}
 	}
 
 	return qr, nil
@@ -107,33 +111,63 @@ func (qr *QueryResult) Empty() bool {
 }
 
 func (qr *QueryResult) parseResults(raw_result_set []interface{}) error {
-	header := raw_result_set[0]
-	qr.parseHeader(header)
+	if err := qr.parseHeader(raw_result_set[0]); err != nil {
+		return err
+	}
 	return qr.parseRecords(raw_result_set)
 }
 
-func (qr *QueryResult) parseStatistics(raw_statistics interface{}) {
-	statistics := raw_statistics.([]interface{})
+func (qr *QueryResult) parseStatistics(raw_statistics interface{}) error {
+	statistics, ok := raw_statistics.([]interface{})
+	if !ok {
+		return fmt.Errorf("malformed statistics: unexpected type %T", raw_statistics)
+	}
 	qr.statistics = make(map[string]float64)
 
 	for _, rs := range statistics {
-		v := strings.Split(rs.(string), ": ")
-		f, _ := strconv.ParseFloat(strings.Split(v[1], " ")[0], 64)
-		qr.statistics[v[0]] = f
+		stat, ok := rs.(string)
+		if !ok {
+			return fmt.Errorf("malformed statistic: unexpected type %T", rs)
+		}
+		// Statistics arrive as "Nodes created: 1" or
+		// "Query internal execution time: 0.1 milliseconds".
+		name, value, found := strings.Cut(stat, ": ")
+		if !found {
+			return fmt.Errorf("malformed statistic %q: expected \"name: value\"", stat)
+		}
+		f, _ := strconv.ParseFloat(strings.Split(value, " ")[0], 64)
+		qr.statistics[name] = f
 	}
+	return nil
 }
 
-func (qr *QueryResult) parseHeader(raw_header interface{}) {
-	header := raw_header.([]interface{})
+func (qr *QueryResult) parseHeader(raw_header interface{}) error {
+	header, ok := raw_header.([]interface{})
+	if !ok {
+		return fmt.Errorf("malformed header: unexpected type %T", raw_header)
+	}
 
 	for _, col := range header {
-		c := col.([]interface{})
-		ct := c[0].(int64)
-		cn := c[1].(string)
+		c, ok := col.([]interface{})
+		if !ok {
+			return fmt.Errorf("malformed header column: unexpected type %T", col)
+		}
+		if len(c) < 2 {
+			return fmt.Errorf("malformed header column: expected 2 elements, got %d", len(c))
+		}
+		ct, ok := c[0].(int64)
+		if !ok {
+			return fmt.Errorf("malformed header column type: unexpected type %T", c[0])
+		}
+		cn, ok := c[1].(string)
+		if !ok {
+			return fmt.Errorf("malformed header column name: unexpected type %T", c[1])
+		}
 
 		qr.header.column_types = append(qr.header.column_types, ResultSetColumnTypes(ct))
 		qr.header.column_names = append(qr.header.column_names, cn)
 	}
+	return nil
 }
 
 func (qr *QueryResult) parseRecords(raw_result_set []interface{}) error {

--- a/query_result.go
+++ b/query_result.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/olekukonko/tablewriter/tw"
@@ -49,6 +50,10 @@ const (
 	VALUE_MAP
 	VALUE_POINT
 	VALUE_VECTORF32
+	VALUE_DATETIME
+	VALUE_DATE
+	VALUE_TIME
+	VALUE_DURATION
 )
 
 type QueryResultHeader struct {
@@ -77,12 +82,20 @@ func QueryResultNew(g *Graph, response interface{}) (*QueryResult, error) {
 		currentRecordIdx: -1,
 	}
 
-	r := response.([]interface{})
+	r, ok := response.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unexpected response type %T", response)
+	}
 
 	if len(r) == 1 {
 		qr.parseStatistics(r[0])
 	} else {
-		qr.parseResults(r)
+		if len(r) < 3 {
+			return nil, fmt.Errorf("malformed response: expected 3 elements, got %d", len(r))
+		}
+		if err := qr.parseResults(r); err != nil {
+			return nil, err
+		}
 		qr.parseStatistics(r[2])
 	}
 
@@ -93,10 +106,10 @@ func (qr *QueryResult) Empty() bool {
 	return len(qr.results) == 0
 }
 
-func (qr *QueryResult) parseResults(raw_result_set []interface{}) {
+func (qr *QueryResult) parseResults(raw_result_set []interface{}) error {
 	header := raw_result_set[0]
 	qr.parseHeader(header)
-	qr.parseRecords(raw_result_set)
+	return qr.parseRecords(raw_result_set)
 }
 
 func (qr *QueryResult) parseStatistics(raw_statistics interface{}) {
@@ -302,6 +315,16 @@ func (qr *QueryResult) parseVectorF32(cell interface{}) ([]float32, error) {
 	return res, nil
 }
 
+// parseTemporal decodes a DATETIME, DATE or TIME value. FalkorDB encodes all
+// three as seconds since the Unix epoch.
+func (qr *QueryResult) parseTemporal(cell interface{}) (time.Time, error) {
+	seconds, ok := cell.(int64)
+	if !ok {
+		return time.Time{}, fmt.Errorf("unexpected temporal value type %T", cell)
+	}
+	return time.Unix(seconds, 0).UTC(), nil
+}
+
 func (qr *QueryResult) parseScalar(cell []interface{}) (interface{}, error) {
 	t := cell[0].(int64)
 	v := cell[1]
@@ -342,11 +365,21 @@ func (qr *QueryResult) parseScalar(cell []interface{}) (interface{}, error) {
 	case VALUE_VECTORF32:
 		return qr.parseVectorF32(v)
 
+	case VALUE_DATETIME, VALUE_DATE, VALUE_TIME:
+		return qr.parseTemporal(v)
+
+	case VALUE_DURATION:
+		seconds, ok := v.(int64)
+		if !ok {
+			return nil, fmt.Errorf("unexpected duration value type %T", v)
+		}
+		return time.Duration(seconds) * time.Second, nil
+
 	case VALUE_UNKNOWN:
 		return nil, errors.New("unknown scalar type")
 	}
 
-	return nil, errors.New("unknown scalar type")
+	return nil, fmt.Errorf("unknown scalar type %d", t)
 }
 
 func (qr *QueryResult) getStat(stat string) float64 {

--- a/query_result_test.go
+++ b/query_result_test.go
@@ -1,0 +1,174 @@
+package falkordb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Passing a parameter whose type ToString did not handle used to panic the
+// caller's program from inside Query.
+func TestQueryParamTypesDoNotPanic(t *testing.T) {
+	params := []interface{}{
+		int32(33), int16(33), int8(33), uint(33), uint64(33),
+		float32(33.5), []int{1, 2, 3}, []byte("John Doe"),
+		90 * time.Second, map[string]int{"a": 1},
+	}
+
+	for _, p := range params {
+		require.NotPanics(t, func() {
+			_, err := graph.Query("RETURN $p", map[string]interface{}{"p": p}, nil)
+			assert.NoError(t, err)
+		}, "param %T", p)
+	}
+}
+
+func TestQueryParamRoundTrip(t *testing.T) {
+	res, err := graph.Query(
+		"RETURN $a AS a, $b AS b, $c AS c",
+		map[string]interface{}{"a": int32(7), "b": float32(1.5), "c": []int{1, 2}},
+		nil,
+	)
+	require.NoError(t, err)
+	require.True(t, res.Next())
+
+	a, err := res.Record().GetByIndex(0)
+	require.NoError(t, err)
+	assert.Equal(t, int64(7), a)
+
+	b, err := res.Record().GetByIndex(1)
+	require.NoError(t, err)
+	assert.InDelta(t, 1.5, b, 0.0001)
+
+	c, err := res.Record().GetByIndex(2)
+	require.NoError(t, err)
+	assert.Equal(t, []interface{}{int64(1), int64(2)}, c)
+}
+
+func TestQueryRejectsUnsupportedParam(t *testing.T) {
+	_, err := graph.Query("RETURN $p", map[string]interface{}{"p": make(chan int)}, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnsupportedType)
+}
+
+// CallProcedure used to iterate the argument indices rather than the arguments,
+// emitting `CALL algo.pageRank(0,1)`. That form is accepted by the server but
+// matches nothing, so the bug silently returned empty results.
+func TestCallProcedurePassesArguments(t *testing.T) {
+	res, err := graph.CallProcedure("algo.pageRank", []string{"node", "score"}, "Person", "Visited")
+	require.NoError(t, err)
+	require.True(t, res.Next(), "procedure should receive the argument values, not their indices")
+
+	node, err := res.Record().GetByIndex(0)
+	require.NoError(t, err)
+	assert.Equal(t, "John Doe", node.(*Node).GetProperty("name"))
+}
+
+func TestCallProcedureRejectsUnsupportedArgument(t *testing.T) {
+	_, err := graph.CallProcedure("db.labels", nil, make(chan int))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnsupportedType)
+}
+
+// FalkorDB encodes DATETIME, DATE and TIME as seconds since the Unix epoch and
+// DURATION as a number of seconds. Before these types were decoded the records
+// were silently dropped and Query returned no error at all.
+func TestTemporalTypes(t *testing.T) {
+	res, err := graph.Query("RETURN date(), localtime(), localdatetime(), duration({days: 2})", nil, nil)
+	require.NoError(t, err)
+	require.True(t, res.Next())
+
+	values := res.Record().Values()
+	require.Len(t, values, 4)
+
+	for i, name := range []string{"date", "localtime", "localdatetime"} {
+		ts, ok := values[i].(time.Time)
+		require.True(t, ok, "%s should decode to time.Time, got %T", name, values[i])
+		assert.False(t, ts.IsZero(), "%s should not be the zero time", name)
+		assert.WithinDuration(t, time.Now().UTC(), ts, 48*time.Hour, "%s should be close to now", name)
+	}
+
+	assert.Equal(t, 48*time.Hour, values[3])
+}
+
+func TestParseScalarTemporalValues(t *testing.T) {
+	qr := &QueryResult{graph: graph}
+
+	// 1787011200 is 2026-08-18T00:00:00Z.
+	ts, err := qr.parseScalar([]interface{}{int64(VALUE_DATE), int64(1787011200)})
+	require.NoError(t, err)
+	assert.Equal(t, time.Date(2026, 8, 18, 0, 0, 0, 0, time.UTC), ts)
+
+	d, err := qr.parseScalar([]interface{}{int64(VALUE_DURATION), int64(172800)})
+	require.NoError(t, err)
+	assert.Equal(t, 48*time.Hour, d)
+}
+
+// The compact protocol type IDs are positional, so a value appended in the
+// wrong place would silently mis-decode every temporal value.
+func TestScalarTypeIDsMatchProtocol(t *testing.T) {
+	assert.Equal(t, ResultSetScalarTypes(11), VALUE_POINT)
+	assert.Equal(t, ResultSetScalarTypes(12), VALUE_VECTORF32)
+	assert.Equal(t, ResultSetScalarTypes(13), VALUE_DATETIME)
+	assert.Equal(t, ResultSetScalarTypes(14), VALUE_DATE)
+	assert.Equal(t, ResultSetScalarTypes(15), VALUE_TIME)
+	assert.Equal(t, ResultSetScalarTypes(16), VALUE_DURATION)
+}
+
+// parseResults used to discard the error from parseRecords, so QueryResultNew
+// reported success while handing back a slice of nil Records.
+func TestQueryResultNewPropagatesParseError(t *testing.T) {
+	response := []interface{}{
+		[]interface{}{[]interface{}{int64(COLUMN_SCALAR), "n"}},
+		[]interface{}{[]interface{}{[]interface{}{int64(99), "x"}}},
+		[]interface{}{"Query internal execution time: 0.1 milliseconds"},
+	}
+
+	qr, err := QueryResultNew(graph, response)
+	require.Error(t, err)
+	assert.Nil(t, qr)
+	assert.Contains(t, err.Error(), "unknown scalar type")
+}
+
+func TestQueryResultNewRejectsMalformedResponse(t *testing.T) {
+	_, err := QueryResultNew(graph, "not a response")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected response type")
+
+	_, err = QueryResultNew(graph, []interface{}{"header", "records"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "malformed response")
+}
+
+// End-to-end proof that a hostile map key cannot escape its literal. The
+// payload below used to create a `:Pwned` node and comment out the query.
+func TestQueryParamCannotInjectCypher(t *testing.T) {
+	db, err := FromURL("falkor://0.0.0.0:6379")
+	require.NoError(t, err)
+	victim := db.SelectGraph("injection_regression")
+	defer victim.Delete()
+
+	_, err = victim.Query("CREATE (:Marker)", nil, nil)
+	require.NoError(t, err)
+
+	params := map[string]interface{}{
+		"p": map[string]interface{}{"x: 1} CREATE (:Pwned) //": 1},
+	}
+	res, err := victim.Query("RETURN $p", params, nil)
+	require.NoError(t, err, "the payload should be inert, not a syntax error")
+	require.True(t, res.Next())
+
+	value, err := res.Record().GetByIndex(0)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"x: 1} CREATE (:Pwned) //": int64(1)}, value,
+		"the key must survive as data")
+
+	count, err := victim.Query("MATCH (n:Pwned) RETURN count(n)", nil, nil)
+	require.NoError(t, err)
+	require.True(t, count.Next())
+	created, err := count.Record().GetByIndex(0)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), created, "no node may be created by a parameter value")
+}

--- a/query_result_test.go
+++ b/query_result_test.go
@@ -172,3 +172,30 @@ func TestQueryParamCannotInjectCypher(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), created, "no node may be created by a parameter value")
 }
+
+// A malformed response must produce an error rather than panic the caller.
+func TestMalformedResponsesReportErrors(t *testing.T) {
+	stats := []interface{}{"Cached execution: 0"}
+	header := []interface{}{[]interface{}{int64(COLUMN_SCALAR), "n"}}
+
+	tests := map[string]interface{}{
+		"statistics not a list":   []interface{}{"nope"},
+		"statistic not a string":  []interface{}{[]interface{}{int64(1)}},
+		"statistic without colon": []interface{}{[]interface{}{"no separator"}},
+		"header not a list":       []interface{}{"nope", []interface{}{}, stats},
+		"header column not list":  []interface{}{[]interface{}{"nope"}, []interface{}{}, stats},
+		"header column too short": []interface{}{[]interface{}{[]interface{}{int64(1)}}, []interface{}{}, stats},
+		"header type not int":     []interface{}{[]interface{}{[]interface{}{"x", "n"}}, []interface{}{}, stats},
+		"header name not string":  []interface{}{[]interface{}{[]interface{}{int64(1), int64(2)}}, []interface{}{}, stats},
+		"trailing stats bad":      []interface{}{header, []interface{}{}, "nope"},
+	}
+
+	for name, response := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				_, err := QueryResultNew(graph, response)
+				assert.Error(t, err)
+			})
+		})
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -3,69 +3,207 @@ package falkordb
 import (
 	"crypto/rand"
 	"fmt"
+	"math"
+	"reflect"
+	"sort"
 	"strconv"
 	"strings"
+	"time"
+	"unicode/utf8"
 )
 
-// go array to string is [1 2 3] for [1, 2, 3] array
-// cypher expects comma separated array
-func arrayToString(arr []interface{}) string {
-	var arrayLength = len(arr)
-	strArray := []string{}
-	for i := 0; i < arrayLength; i++ {
-		strArray = append(strArray, ToString(arr[i]))
+// maxNestingDepth bounds the recursion in toString. Cyclic values (a map or
+// slice that contains itself) would otherwise recurse until the goroutine stack
+// overflows, which is a fatal error that recover cannot catch.
+const maxNestingDepth = 100
+
+// quoteCypherString renders s as a Cypher double-quoted string literal.
+//
+// strconv.Quote is deliberately not used: it escapes control bytes as \xNN and
+// non-printable runes as \uXXXX, neither of which FalkorDB decodes, so such
+// values would be silently corrupted. Only the escapes the server understands
+// are emitted and every other byte, including all multi-byte UTF-8, is passed
+// through verbatim.
+func quoteCypherString(s string) (string, error) {
+	var b strings.Builder
+	b.Grow(len(s) + 2)
+	b.WriteByte('"')
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; c {
+		case 0:
+			return "", fmt.Errorf("%w: string contains a NUL byte at offset %d", ErrUnsupportedType, i)
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			b.WriteByte(c)
+		}
 	}
-	return "[" + strings.Join(strArray, ",") + "]"
+	b.WriteByte('"')
+	return b.String(), nil
 }
 
-// go array to string is [1 2 3] for [1, 2, 3] array
-// cypher expects comma separated array
-func strArrayToString(arr []string) string {
-	var arrayLength = len(arr)
-	strArray := []string{}
-	for i := 0; i < arrayLength; i++ {
-		strArray = append(strArray, ToString(arr[i]))
+// quoteCypherIdentifier renders name as a back-quoted Cypher identifier, which
+// is what map keys are. Without the back quotes a key such as
+// `x: 1} CREATE (:Pwned) //` would close the map literal and append arbitrary
+// clauses to the query.
+func quoteCypherIdentifier(name string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("%w: empty identifier", ErrUnsupportedType)
 	}
-	return "[" + strings.Join(strArray, ",") + "]"
+	// FalkorDB has no escape for a back quote inside a back-quoted identifier,
+	// so such a name cannot be rendered safely.
+	if strings.ContainsAny(name, "`\x00") {
+		return "", fmt.Errorf("%w: identifier %q contains a back quote or NUL byte", ErrUnsupportedType, name)
+	}
+	return "`" + name + "`", nil
 }
 
-func mapToString(data map[string]interface{}) string {
-	pairsArray := []string{}
-	for k, v := range data {
-		pairsArray = append(pairsArray, k+": "+ToString(v))
+// sliceToString renders a slice or array as a Cypher list literal.
+func sliceToString(rv reflect.Value, depth int) (string, error) {
+	elements := make([]string, rv.Len())
+	for i := 0; i < rv.Len(); i++ {
+		s, err := toStringDepth(rv.Index(i).Interface(), depth+1)
+		if err != nil {
+			return "", err
+		}
+		elements[i] = s
 	}
-	return "{" + strings.Join(pairsArray, ",") + "}"
+	return "[" + strings.Join(elements, ",") + "]", nil
 }
 
-func ToString(i interface{}) string {
+// mapValueToString renders a map with string keys as a Cypher map literal. Keys
+// are sorted so that the same map always produces the same query text, which
+// keeps FalkorDB's query cache effective.
+func mapValueToString(rv reflect.Value, depth int) (string, error) {
+	if rv.Type().Key().Kind() != reflect.String {
+		return "", fmt.Errorf("%w: map key %s, only string keys are supported", ErrUnsupportedType, rv.Type().Key())
+	}
+
+	keys := rv.MapKeys()
+	sort.Slice(keys, func(i, j int) bool { return keys[i].String() < keys[j].String() })
+
+	pairs := make([]string, 0, len(keys))
+	for _, k := range keys {
+		key, err := quoteCypherIdentifier(k.String())
+		if err != nil {
+			return "", err
+		}
+		s, err := toStringDepth(rv.MapIndex(k).Interface(), depth+1)
+		if err != nil {
+			return "", err
+		}
+		pairs = append(pairs, key+": "+s)
+	}
+	return "{" + strings.Join(pairs, ",") + "}", nil
+}
+
+// toString converts a Go value to its Cypher literal representation, reporting
+// ErrUnsupportedType for values it cannot represent rather than panicking.
+func toString(i interface{}) (string, error) {
+	return toStringDepth(i, 0)
+}
+
+func toStringDepth(i interface{}, depth int) (string, error) {
 	if i == nil {
-		return "null"
+		return "null", nil
+	}
+	if depth > maxNestingDepth {
+		return "", fmt.Errorf("%w: value nested deeper than %d levels, or self-referential", ErrUnsupportedType, maxNestingDepth)
 	}
 
-	switch i.(type) {
+	// Types whose underlying kind would otherwise be matched by the reflection
+	// switch below have to be handled first: time.Duration is an int64 and
+	// []byte is a []uint8.
+	switch v := i.(type) {
 	case string:
-		s := i.(string)
-		return strconv.Quote(s)
-	case int:
-		return strconv.Itoa(i.(int))
-	case int64:
-		return strconv.FormatInt(i.(int64), 10)
-	case float64:
-		return strconv.FormatFloat(i.(float64), 'f', -1, 64)
+		return quoteCypherString(v)
 	case bool:
-		return strconv.FormatBool(i.(bool))
-	case []interface{}:
-		arr := i.([]interface{})
-		return arrayToString(arr)
-	case map[string]interface{}:
-		data := i.(map[string]interface{})
-		return mapToString(data)
-	case []string:
-		arr := i.([]string)
-		return strArrayToString(arr)
-	default:
-		panic("Unrecognized type to convert to string")
+		return strconv.FormatBool(v), nil
+	case []byte:
+		if !utf8.Valid(v) {
+			return "", fmt.Errorf("%w: []byte is not valid UTF-8, FalkorDB strings cannot carry arbitrary binary", ErrUnsupportedType)
+		}
+		return quoteCypherString(string(v))
+	case time.Time:
+		return quoteCypherString(v.Format(time.RFC3339Nano))
+	case time.Duration:
+		// FalkorDB's DURATION type has second granularity, so sub-second
+		// components are truncated.
+		return strconv.FormatInt(int64(v/time.Second), 10), nil
 	}
+
+	rv := reflect.ValueOf(i)
+	switch rv.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return strconv.FormatInt(rv.Int(), 10), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		// FalkorDB integers are signed 64-bit and the server saturates rather
+		// than reporting an error, so reject values it cannot represent.
+		if u := rv.Uint(); u > math.MaxInt64 {
+			return "", fmt.Errorf("%w: uint value %d exceeds the int64 range FalkorDB supports", ErrUnsupportedType, u)
+		}
+		return strconv.FormatUint(rv.Uint(), 10), nil
+	case reflect.Float32, reflect.Float64:
+		f := rv.Float()
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			return "", fmt.Errorf("%w: %v has no Cypher representation", ErrUnsupportedType, f)
+		}
+		bitSize := 64
+		if rv.Kind() == reflect.Float32 {
+			bitSize = 32
+		}
+		return strconv.FormatFloat(f, 'f', -1, bitSize), nil
+	case reflect.Slice, reflect.Array:
+		if rv.Kind() == reflect.Slice && rv.IsNil() {
+			return "null", nil
+		}
+		return sliceToString(rv, depth)
+	case reflect.Map:
+		if rv.IsNil() {
+			return "null", nil
+		}
+		return mapValueToString(rv, depth)
+	case reflect.Pointer, reflect.Interface:
+		if rv.IsNil() {
+			return "null", nil
+		}
+		return toStringDepth(rv.Elem().Interface(), depth+1)
+	}
+
+	return "", fmt.Errorf("%w: %T", ErrUnsupportedType, i)
+}
+
+// ToString returns the Cypher literal representation of i.
+//
+// Values that cannot be represented fall back to a description of their type,
+// so that rendering a value never panics. Use query parameters, which report
+// ErrUnsupportedType, when the conversion needs to be checked.
+func ToString(i interface{}) string {
+	s, err := toString(i)
+	if err == nil {
+		return s
+	}
+
+	// Deliberately not fmt.Sprint(i): it walks the value and recurses forever
+	// on cyclic input, and a stack overflow is a fatal error that no caller can
+	// recover from. %T inspects only the type.
+	if stringer, ok := i.(fmt.Stringer); ok {
+		if quoted, qerr := quoteCypherString(stringer.String()); qerr == nil {
+			return quoted
+		}
+	}
+	if quoted, qerr := quoteCypherString(fmt.Sprintf("<unsupported %T>", i)); qerr == nil {
+		return quoted
+	}
+	return `""`
 }
 
 // https://medium.com/@kpbird/golang-generate-fixed-size-random-string-dd6dbd5e63c0
@@ -93,6 +231,55 @@ func RandomString(n int) string {
 	return string(output)
 }
 
+// isValidParamName reports whether name is a plain Cypher identifier. Parameter
+// names are interpolated into the query text, so a name such as
+// `x=1 CREATE (:Pwned) //` would otherwise append arbitrary clauses.
+func isValidParamName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c == '_':
+		case c >= '0' && c <= '9' && i > 0:
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// buildParamsHeader renders the CYPHER parameter preamble for a query,
+// reporting an error for any parameter that cannot be represented. Parameters
+// are emitted in sorted key order so that the same set of parameters always
+// produces the same query text, which keeps FalkorDB's query cache effective.
+func buildParamsHeader(params map[string]interface{}) (string, error) {
+	keys := make([]string, 0, len(params))
+	for key := range params {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var header strings.Builder
+	header.WriteString("CYPHER ")
+	for _, key := range keys {
+		if !isValidParamName(key) {
+			return "", fmt.Errorf("%w: parameter name %q is not a valid identifier", ErrUnsupportedType, key)
+		}
+		value, err := toString(params[key])
+		if err != nil {
+			return "", fmt.Errorf("parameter %q: %w", key, err)
+		}
+		header.WriteString(key)
+		header.WriteString("=")
+		header.WriteString(value)
+		header.WriteString(" ")
+	}
+	return header.String(), nil
+}
+
+// BuildParamsHeader renders the CYPHER parameter preamble for a query.
 func BuildParamsHeader(params map[string]interface{}) string {
 	header := "CYPHER "
 	for key, value := range params {

--- a/utils.go
+++ b/utils.go
@@ -25,6 +25,13 @@ const maxNestingDepth = 100
 // are emitted and every other byte, including all multi-byte UTF-8, is passed
 // through verbatim.
 func quoteCypherString(s string) (string, error) {
+	// FalkorDB strings are UTF-8 text, so invalid input has to be rejected
+	// rather than passed through to be stored incorrectly. []byte is routed
+	// here too, so both follow the same rule.
+	if !utf8.ValidString(s) {
+		return "", fmt.Errorf("%w: string is not valid UTF-8", ErrUnsupportedType)
+	}
+
 	var b strings.Builder
 	b.Grow(len(s) + 2)
 	b.WriteByte('"')
@@ -128,9 +135,6 @@ func toStringDepth(i interface{}, depth int) (string, error) {
 	case bool:
 		return strconv.FormatBool(v), nil
 	case []byte:
-		if !utf8.Valid(v) {
-			return "", fmt.Errorf("%w: []byte is not valid UTF-8, FalkorDB strings cannot carry arbitrary binary", ErrUnsupportedType)
-		}
 		return quoteCypherString(string(v))
 	case time.Time:
 		return quoteCypherString(v.Format(time.RFC3339Nano))

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,198 @@
+package falkordb
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// namedKey exercises map keys whose underlying kind is a string but whose type
+// is not string itself.
+type namedKey string
+
+// Every one of these types used to panic ToString with
+// "Unrecognized type to convert to string".
+func TestToStringSupportedTypes(t *testing.T) {
+	sample := time.Date(2026, 8, 18, 20, 18, 4, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		value    interface{}
+		expected string
+	}{
+		{"nil", nil, "null"},
+		{"string", "hello", `"hello"`},
+		{"string with quotes", `say "hi"`, `"say \"hi\""`},
+		{"string with backslash", `a\\b`, `"a\\\\b"`},
+		{"newline", "a\nb", `"a\nb"`},
+		{"non-ascii passes through", "café", `"café"`},
+		{"nbsp passes through", "a\u00a0b", "\"a\u00a0b\""},
+		{"bool", true, "true"},
+		{"int", 42, "42"},
+		{"int8", int8(8), "8"},
+		{"int16", int16(16), "16"},
+		{"int32", int32(32), "32"},
+		{"int64", int64(64), "64"},
+		{"negative int", -7, "-7"},
+		{"uint", uint(1), "1"},
+		{"uint8", uint8(2), "2"},
+		{"uint16", uint16(3), "3"},
+		{"uint32", uint32(4), "4"},
+		{"uint64", uint64(5), "5"},
+		{"float32", float32(1.5), "1.5"},
+		{"float64", 2.25, "2.25"},
+		{"bytes", []byte("raw"), `"raw"`},
+		{"time", sample, `"2026-08-18T20:18:04Z"`},
+		{"duration", 90 * time.Second, "90"},
+		{"[]interface{}", []interface{}{1, "a"}, `[1,"a"]`},
+		{"[]string", []string{"a", "b"}, `["a","b"]`},
+		{"[]int", []int{1, 2, 3}, "[1,2,3]"},
+		{"[]float64", []float64{1.5, 2.5}, "[1.5,2.5]"},
+		{"[]bool", []bool{true, false}, "[true,false]"},
+		{"array", [2]int{7, 8}, "[7,8]"},
+		{"nested slice", []interface{}{[]int{1}}, "[[1]]"},
+		{"nil slice", []string(nil), "null"},
+		{"empty slice", []int{}, "[]"},
+		{"map", map[string]interface{}{"a": 1}, "{`a`: 1}"},
+		{"map[string]int", map[string]int{"a": 1, "b": 2}, "{`a`: 1,`b`: 2}"},
+		{"map with named key type", map[namedKey]int{"b": 2, "a": 1}, "{`a`: 1,`b`: 2}"},
+		{"nil map", map[string]interface{}(nil), "null"},
+		{"pointer", func() *int { v := 5; return &v }(), "5"},
+		{"nil pointer", (*int)(nil), "null"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := toString(tt.value)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+			assert.Equal(t, tt.expected, ToString(tt.value))
+		})
+	}
+}
+
+func TestToStringUnsupportedTypeReturnsError(t *testing.T) {
+	_, err := toString(make(chan int))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnsupportedType)
+
+	_, err = toString(map[int]string{1: "a"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnsupportedType)
+
+	// An unsupported value nested inside a container is reported too.
+	_, err = toString([]interface{}{1, make(chan int)})
+	assert.ErrorIs(t, err, ErrUnsupportedType)
+}
+
+// ToString keeps its signature and must never panic, even for values it cannot
+// represent, because Node.Encode and Edge.Encode render properties with it.
+func TestToStringNeverPanics(t *testing.T) {
+	assert.NotPanics(t, func() { ToString(make(chan int)) })
+	assert.NotPanics(t, func() { ToString(struct{ A int }{1}) })
+}
+
+func TestBuildParamsHeaderIsDeterministic(t *testing.T) {
+	params := map[string]interface{}{"b": 2, "a": 1, "c": "x"}
+
+	header, err := buildParamsHeader(params)
+	require.NoError(t, err)
+	assert.Equal(t, `CYPHER a=1 b=2 c="x" `, header)
+
+	// Sorted keys mean repeated calls produce identical query text, which keeps
+	// FalkorDB's query cache effective.
+	for i := 0; i < 20; i++ {
+		repeated, err := buildParamsHeader(params)
+		require.NoError(t, err)
+		assert.Equal(t, header, repeated)
+	}
+}
+
+func TestBuildParamsHeaderReportsBadParam(t *testing.T) {
+	_, err := buildParamsHeader(map[string]interface{}{"bad": make(chan int)})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnsupportedType)
+	assert.Contains(t, err.Error(), `parameter "bad"`)
+}
+
+func TestBuildParamsHeaderEmpty(t *testing.T) {
+	header, err := buildParamsHeader(map[string]interface{}{})
+	require.NoError(t, err)
+	assert.Equal(t, "CYPHER ", header)
+}
+
+// A map key is interpolated into the query text, so it must be back-quoted or a
+// crafted key can close the map literal and append arbitrary clauses. The
+// payload below created a `:Pwned` node and commented out the caller's query.
+func TestMapKeyCannotInjectCypher(t *testing.T) {
+	payload := "x: 1} CREATE (:Pwned) //"
+
+	got, err := toString(map[string]interface{}{payload: 1})
+	require.NoError(t, err)
+	assert.Equal(t, "{`x: 1} CREATE (:Pwned) //`: 1}", got)
+
+	// A key that cannot be back-quoted safely is rejected outright.
+	_, err = toString(map[string]interface{}{"has`backquote": 1})
+	assert.ErrorIs(t, err, ErrUnsupportedType)
+}
+
+func TestParamNameMustBeIdentifier(t *testing.T) {
+	for _, name := range []string{
+		"x=1 CREATE (:Pwned) //", "", "1abc", "a-b", "a b", "a`b", `a"b`,
+	} {
+		_, err := buildParamsHeader(map[string]interface{}{name: 1})
+		assert.ErrorIsf(t, err, ErrUnsupportedType, "name %q must be rejected", name)
+	}
+
+	for _, name := range []string{"a", "_a", "A1", "snake_case_1"} {
+		_, err := buildParamsHeader(map[string]interface{}{name: 1})
+		assert.NoErrorf(t, err, "name %q must be accepted", name)
+	}
+}
+
+// strconv.Quote would render these as \xNN or \uXXXX, which FalkorDB does not
+// decode, silently corrupting the value.
+func TestStringEscapingMatchesServer(t *testing.T) {
+	_, err := toString("a\x00b")
+	assert.ErrorIs(t, err, ErrUnsupportedType, "NUL cannot be carried and must be rejected")
+
+	_, err = toString([]byte{0xff, 0xfe})
+	assert.ErrorIs(t, err, ErrUnsupportedType, "invalid UTF-8 must be rejected")
+
+	got, err := toString("a\u00a0b")
+	require.NoError(t, err)
+	assert.Equal(t, "\"a\u00a0b\"", got, "NBSP must pass through, not become \\u00a0")
+}
+
+func TestNumericLimits(t *testing.T) {
+	_, err := toString(uint64(math.MaxUint64))
+	assert.ErrorIs(t, err, ErrUnsupportedType, "uint64 above MaxInt64 is silently clamped by the server")
+
+	got, err := toString(uint64(math.MaxInt64))
+	require.NoError(t, err)
+	assert.Equal(t, "9223372036854775807", got)
+
+	for _, f := range []float64{math.NaN(), math.Inf(1), math.Inf(-1)} {
+		_, err := toString(f)
+		assert.ErrorIs(t, err, ErrUnsupportedType)
+	}
+}
+
+// A stack overflow is a fatal error that recover cannot catch, so cyclic values
+// have to be rejected rather than followed.
+func TestCyclicValuesAreRejected(t *testing.T) {
+	m := map[string]interface{}{}
+	m["self"] = m
+	_, err := toString(m)
+	assert.ErrorIs(t, err, ErrUnsupportedType)
+
+	s := make([]interface{}, 1)
+	s[0] = s
+	_, err = toString(s)
+	assert.ErrorIs(t, err, ErrUnsupportedType)
+
+	assert.NotPanics(t, func() { ToString(m) })
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -196,3 +196,18 @@ func TestCyclicValuesAreRejected(t *testing.T) {
 
 	assert.NotPanics(t, func() { ToString(m) })
 }
+
+// FalkorDB strings are UTF-8 text, so a Go string holding invalid UTF-8 must be
+// rejected on the same terms as a []byte rather than stored incorrectly.
+func TestInvalidUTF8Rejected(t *testing.T) {
+	for name, v := range map[string]interface{}{
+		"string": "a\xffb",
+		"bytes":  []byte{0xff, 0xfe},
+	} {
+		_, err := toString(v)
+		assert.ErrorIsf(t, err, ErrUnsupportedType, "%s must be rejected", name)
+	}
+
+	// The fallback in ToString must cope with it too.
+	assert.NotPanics(t, func() { ToString("a\xffb") })
+}


### PR DESCRIPTION
## Summary

A correctness pass over the query parameter and result-parsing paths. Every problem below was **reproduced against FalkorDB v4.20.3 before being fixed**, and each has a regression test that fails if the fix is reverted.

The most serious finding is a **Cypher injection through map keys**: map keys were interpolated into the query text unquoted, so a crafted key closed the map literal and appended arbitrary clauses.

```go
params := map[string]interface{}{"p": map[string]interface{}{"x: 1} CREATE (:Pwned) //": 1}}
graph.Query("MATCH (n:Person) RETURN $p", params, nil)
```

emitted `CYPHER p={x: 1} CREATE (:Pwned) //: 1} MATCH (n:Person) RETURN $p`. Verified on a live server: the `:Pwned` node was created and the caller's query never ran. Realistic because map parameters are exactly what you get from `json.Unmarshal`.

## Changes

**Panics reachable from user input**
- `ToString` panicked with `Unrecognized type to convert to string` for `int32`, `uint`, `float32`, `[]int` and most other ordinary types. It is reachable via `Query` → `BuildParamsHeader` → `ToString`, so `map[string]interface{}{"age": int32(33)}` crashed the caller's process. Conversion is now an internal `toString` returning `ErrUnsupportedType`; the exported `ToString` keeps its signature and never panics.
- Cyclic values (`m["self"] = m`) recursed until the stack overflowed — a `fatal error` that `recover` cannot catch. Now depth-bounded.

**Injection**
- Map keys are back-quoted; keys containing a back quote are rejected.
- Parameter names must be plain Cypher identifiers.

**Silent corruption**
- `strconv.Quote` emits `\xNN` and `\uXXXX`, which FalkorDB does not decode (`RETURN size("a\x00b")` → `6`, not `3`). Replaced with a Cypher-specific quoter that passes UTF-8 through verbatim.
- `uint64` above `MaxInt64` is saturated by the server with no error (`18446744073709551615` → `9223372036854775807`); now rejected.
- `NaN`/`±Inf` produced malformed queries; now rejected.
- `[]byte` must be valid UTF-8, since FalkorDB strings are text.

**Result parsing**
- `parseResults` discarded the error from `parseRecords`, so `QueryResultNew` reported success while returning a slice of nil `Record`s.
- `QueryResultNew`, `parseHeader` and `parseStatistics` asserted response types without checking, so a malformed or partial response panicked the caller. All now return descriptive errors.
- `CallProcedure` iterated argument *indices* rather than the arguments, emitting `CALL algo.pageRank(0,1)`. The server accepts that and matches nothing, so it failed silently.
- `DATETIME`, `DATE`, `TIME`, `DURATION` were not decoded. Combined with the swallowed error, `RETURN date()` returned **nil with no error**. Type IDs 13–16 were confirmed directly against the server (`date()`→14, `localtime()`→15, `localdatetime()`→13, `duration({days:2})`→16); the first three are Unix seconds, the last a second count.

**Docs**
- The README example did not compile — it used `GetByIndex` in single-value context although it returns `(interface{}, error)`. Fixed and verified by extracting and running it.
- Documented parameter types, temporal values and the new safety rules.

## Testing

- New `utils_test.go` and `query_result_test.go`; existing suite kept passing.
- `go test -race ./...` clean against a live `falkordb/falkordb:latest` container.
- `go vet` and `gofmt` clean.
- Injection payload asserted inert end-to-end: the key round-trips as data and no node is created.
- README example extracted, compiled and run.
- Coverage **60.6% → 72.1%**.

## Memory / Performance Impact

N/A — no allocation or graph-lifecycle changes. Parameter rendering now sorts keys, which also makes query text stable and so improves FalkorDB query-cache hit rates.

## Related Issues

Supersedes the temporal-type work in #34 (that PR's enum ordering is correct, but its `VALUE_TIME` uses `time.UnixMilli` where the server sends Unix seconds).

## Note on behaviour changes

- `ToString` on a map now back-quotes keys: `{object: {foo: 1}}` → `` {`object`: {`foo`: 1}} ``. This is the injection fix; `TestUtils` was updated.
- Queries that previously returned silent nils for temporal values now return real values; queries with genuinely unparseable responses now return an error instead of nil records.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for query parameters with validation and broader Go value types.
  * Added decoding for FalkorDB temporal values into Go time types.
  * Added an exported error for unsupported parameter values.
* **Bug Fixes**
  * Improved malformed-result and conversion error handling.
  * Prevented invalid values and Cypher-injection attempts from causing unsafe queries or panics.
  * Made parameter and map output deterministic.
* **Documentation**
  * Expanded usage guidance for query parameters, validation, error handling, and temporal values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
